### PR TITLE
NEW: Add robot frame publisher

### DIFF
--- a/mrobot_gazebo/CMakeLists.txt
+++ b/mrobot_gazebo/CMakeLists.txt
@@ -10,6 +10,8 @@ find_package(catkin REQUIRED COMPONENTS
   gazebo_ros_control
   roscpp
   rospy
+  tf2
+  tf2_ros
 )
 
 ## System dependencies are found with CMake's conventions

--- a/mrobot_gazebo/launch/my_gazebo3.launch
+++ b/mrobot_gazebo/launch/my_gazebo3.launch
@@ -35,4 +35,7 @@
     <!-- Load the follow publisher -->
     <node name="publish_follow_target" pkg="publish_follow_target" type="publish_follow_target" output="screen" />
 
+    <!-- Publish the crosswalk transform -->
+    <node name="crosswalk_transform_broadcaster" pkg="publish_follow_target" type="crosswalk_transform_broadcaster" output="screen" />
+
 </launch>

--- a/mrobot_gazebo/package.xml
+++ b/mrobot_gazebo/package.xml
@@ -45,11 +45,15 @@
   <build_depend>gazebo_ros_control</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
+  <build_depend>tf2</build_depend>
+  <build_depend>tf2_ros</build_depend>
   <run_depend>gazebo_plugins</run_depend>
   <run_depend>gazebo_ros</run_depend>
   <run_depend>gazebo_ros_control</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
+  <run_depend>tf2</run_depend>
+  <run_depend>tf2_ros</run_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/publish_follow_target/CMakeLists.txt
+++ b/publish_follow_target/CMakeLists.txt
@@ -159,6 +159,10 @@ target_link_libraries(robot_transform_broadcaster
   ${catkin_LIBRARIES}
 )
 
+add_executable(crosswalk_transform_broadcaster src/crosswalk_transform_broadcaster.cpp)
+target_link_libraries(crosswalk_transform_broadcaster
+  ${catkin_LIBRARIES}
+)
 
 #############
 ## Install ##

--- a/publish_follow_target/CMakeLists.txt
+++ b/publish_follow_target/CMakeLists.txt
@@ -12,6 +12,8 @@ find_package(catkin REQUIRED COMPONENTS
   people_msgs
   roscpp
   rospy
+  tf2
+  tf2_ros
 )
 
 ## System dependencies are found with CMake's conventions
@@ -150,6 +152,13 @@ add_executable(publish_follow_target src/publish_follow_target.cpp)
 target_link_libraries(publish_follow_target
   ${catkin_LIBRARIES}
 )
+
+
+add_executable(robot_transform_broadcaster src/robot_transform_broadcaster.cpp)
+target_link_libraries(robot_transform_broadcaster
+  ${catkin_LIBRARIES}
+)
+
 
 #############
 ## Install ##

--- a/publish_follow_target/src/crosswalk_transform_broadcaster.cpp
+++ b/publish_follow_target/src/crosswalk_transform_broadcaster.cpp
@@ -1,0 +1,31 @@
+#include <ros/ros.h>
+#include <tf2_ros/transform_broadcaster.h>
+#include <tf2/LinearMath/Quaternion.h>
+
+int main(int argc, char** argv){
+  ros::init(argc, argv, "crosswalk_transform_broadcaster");
+  ros::NodeHandle node;
+
+   tf2_ros::TransformBroadcaster tfb;
+  geometry_msgs::TransformStamped transformStamped;
+
+  
+  transformStamped.header.frame_id = "odom";
+  transformStamped.child_frame_id = "crosswalk";
+  transformStamped.transform.translation.x = 0.0;
+  transformStamped.transform.translation.y = 0.0;
+  transformStamped.transform.translation.z = 0.0;
+  tf2::Quaternion q;
+  q.setRPY(0, 0, 0);
+  transformStamped.transform.rotation.x = q.x();
+  transformStamped.transform.rotation.y = q.y();
+  transformStamped.transform.rotation.z = q.z();
+  transformStamped.transform.rotation.w = q.w();
+
+  ros::Rate rate(10.0);
+  while (node.ok()){
+    transformStamped.header.stamp = ros::Time::now();
+    tfb.sendTransform(transformStamped);
+    rate.sleep();
+  }
+};

--- a/publish_follow_target/src/publish_follow_target.cpp
+++ b/publish_follow_target/src/publish_follow_target.cpp
@@ -2,6 +2,10 @@
 #include <gazebo_msgs/ModelStates.h>
 #include <people_msgs/Person.h>
 #include <algorithm>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+
+// Name of the robot (poses are published relative to this)
+std::string robot_name;
 
 // Name of the target to follow (as identified in ModelStates message)
 std::string target_name;
@@ -30,7 +34,7 @@ void callback(const gazebo_msgs::ModelStates::ConstPtr& msg)
   geometry_msgs::Point velocity;
 
   int index = std::distance(msg->name.begin(), std::find(msg->name.begin(), msg->name.end(), target_name));
-  if (index > 0 && index < msg->name.size()) {
+  if (index >= 0 && index < msg->name.size()) {
     if (has_previous_state) {
       ros::Duration duration = current_time - last_time;
       double delta_time = duration.toSec();
@@ -58,11 +62,10 @@ void callback(const gazebo_msgs::ModelStates::ConstPtr& msg)
       person.velocity.x = velocity.x;
       person.velocity.y = velocity.y;
       person.velocity.z = velocity.z;
-      // reliability, tagNames and tags are currently unused
       pub.publish(person);
     }
 
-    // Save state for next call
+    // Save state (in world coordinates) for next call
     old_position.x = msg->pose[index].position.x;
     old_position.y = msg->pose[index].position.y;
     old_position.z = msg->pose[index].position.z;
@@ -92,6 +95,7 @@ int main(int argc, char** argv)
 {
   // Hard coded parameters used by the module (TODO Convert to params in launch file)
   SetTarget("actor_1");
+  robot_name = "mrobot";
   std::string topic_name = "/gazebo/model_states";
   std::string output_topic = "/follow";
 

--- a/publish_follow_target/src/publish_follow_target.cpp
+++ b/publish_follow_target/src/publish_follow_target.cpp
@@ -1,6 +1,6 @@
 #include <ros/ros.h>
 #include <gazebo_msgs/ModelStates.h>
-#include <people_msgs/Person.h>
+#include <people_msgs/PersonStamped.h>
 #include <algorithm>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
@@ -54,14 +54,16 @@ void callback(const gazebo_msgs::ModelStates::ConstPtr& msg)
       //    velocity.x, velocity.y, velocity.z);
 
       // Create and publish the message
-      people_msgs::Person person;
-      person.name = msg->name[index];
-      person.position.x = msg->pose[index].position.x;
-      person.position.y = msg->pose[index].position.y;
-      person.position.z = msg->pose[index].position.z;
-      person.velocity.x = velocity.x;
-      person.velocity.y = velocity.y;
-      person.velocity.z = velocity.z;
+      people_msgs::PersonStamped person;
+      person.header.stamp = ros::Time::now();
+      person.header.frame_id = "crosswalk";
+      person.person.name = msg->name[index];
+      person.person.position.x = msg->pose[index].position.x;
+      person.person.position.y = msg->pose[index].position.y;
+      person.person.position.z = msg->pose[index].position.z;
+      person.person.velocity.x = velocity.x;
+      person.person.velocity.y = velocity.y;
+      person.person.velocity.z = velocity.z;
       pub.publish(person);
     }
 
@@ -104,7 +106,7 @@ int main(int argc, char** argv)
   ros::NodeHandle node;
 
   // Create the publisher
-  pub = node.advertise<people_msgs::Person>("/follow", 1);
+  pub = node.advertise<people_msgs::PersonStamped>("/follow", 1);
   ROS_INFO("Publishing output on %s", output_topic.c_str());
 
   // Create the subscriber

--- a/publish_follow_target/src/robot_transform_broadcaster.cpp
+++ b/publish_follow_target/src/robot_transform_broadcaster.cpp
@@ -1,0 +1,53 @@
+#include <ros/ros.h>
+#include <tf2_ros/transform_broadcaster.h>
+#include <geometry_msgs/TransformStamped.h>
+#include <gazebo_msgs/ModelStates.h>
+
+// The name of the robot model to publish (as given in gazebo)
+std::string robot_name;
+// The reference frame for the robot
+std::string robot_frame;
+
+void callback(const gazebo_msgs::ModelStates::ConstPtr &msg)
+{
+  static tf2_ros::TransformBroadcaster br;
+
+  ros::Time current_time = ros::Time::now();
+  geometry_msgs::TransformStamped transformStamped;
+
+  int index = std::distance(msg->name.begin(), std::find(msg->name.begin(), msg->name.end(), robot_name));
+  if (index >= 0 && index < msg->name.size())
+  {
+    transformStamped.header.stamp = current_time;
+    transformStamped.header.frame_id = "world";
+    transformStamped.child_frame_id = robot_frame;
+    transformStamped.transform.translation.x = msg->pose[index].position.x;
+    transformStamped.transform.translation.y = msg->pose[index].position.y;
+    transformStamped.transform.translation.z = msg->pose[index].position.z;
+    transformStamped.transform.rotation.x = msg->pose[index].orientation.x;
+    transformStamped.transform.rotation.y = msg->pose[index].orientation.y;
+    transformStamped.transform.rotation.z = msg->pose[index].orientation.z;
+    transformStamped.transform.rotation.w = msg->pose[index].orientation.w;
+
+    //ROS_INFO("Publishing Transform %s to %s: (%f, %f, %f) (%f, %f, %f, %f)",
+    //    transformStamped.header.frame_id.c_str(), transformStamped.child_frame_id.c_str(),
+    //    transformStamped.transform.translation.x, transformStamped.transform.translation.y, transformStamped.transform.translation.z,
+    //    transformStamped.transform.rotation.x, transformStamped.transform.rotation.y, transformStamped.transform.rotation.z, transformStamped.transform.rotation.w);
+
+    br.sendTransform(transformStamped);
+  }
+}
+
+int main(int argc, char **argv)
+{
+  robot_name = "mrobot";
+  robot_frame = "base_link";
+
+  ros::init(argc, argv, "robot_transform_broadcaster");
+
+  ros::NodeHandle node;
+  ros::Subscriber sub = node.subscribe("/gazebo/model_states", 1, callback);
+
+  ros::spin();
+  return 0;
+};


### PR DESCRIPTION
I added a transform publisher for the robot position. It can be run using rosrun publish_follow_target robot_transform_broadcaster

It searches gazebo's messages for the robot and creates a transformStamped message for the world -> base_link transform, which you can see using rostopic echo /tf

But I also found gazebo is already publishing the same information under the odom -> base_footprint transform, so you may want to just use that when converting my Person messages